### PR TITLE
Tap type - Set floating point and changed name of parameters

### DIFF
--- a/pyibisami/ami_parameter.py
+++ b/pyibisami/ami_parameter.py
@@ -295,7 +295,7 @@ class AMIParameter:
                 raise AMIParamError("Illegal type, '{}', for use with Range.\n".format(param_type))
             if len(vals) < 3:
                 raise AMIParamError("Insufficient number of values, {}, provided for Range.\n".format(len(vals)))
-            if param_type in ("Float", "UI"):
+            if param_type in ("Float", "UI", "Tap"):
                 try:
                     temp_vals = list(map(float, vals[:3]))
                 except (ValueError, TypeError):
@@ -314,7 +314,7 @@ class AMIParameter:
                     temp_vals = list(map(float, vals))
                 except (ValueError, TypeError):
                     raise AMIParamError("Couldn't read floats from '{}'.\n".format(vals))
-            elif param_type in ("Integer", "Tap"):
+            elif param_type in ("Integer"):
                 try:
                     temp_vals = list(map(int, vals))
                 except (ValueError, TypeError):

--- a/pyibisami/ami_parse.py
+++ b/pyibisami/ami_parse.py
@@ -185,22 +185,13 @@ ignore = many((whitespace | comment))
 def lexeme(p):
     """Lexer for words."""
     return p << ignore  # skip all ignored characters.
-
-def int2tap(x):
-    """Convert integer to tap position."""
-    if (x[0] == '-'):
-        res = ("pre" + x[1:])
-    else:
-        res = ("post" + x)
-    return res
-
-
+    
 lparen = lexeme(string("("))
 rparen = lexeme(string(")"))
 number = lexeme(regex(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?"))
 integ  = lexeme(regex(r"[-+]?[0-9]+"))
 nat    = lexeme(regex(r"[0-9]+"))
-tap_ix = integ.parsecmap(int2tap)
+tap_ix = integ
 symbol = lexeme(regex(r"[a-zA-Z_][^\s()]*"))
 true = lexeme(string("True")).result(True)
 false = lexeme(string("False")).result(False)


### PR DESCRIPTION
According to 10.3.4 RESERVED WORD RULES in IBIS spec Tap is a floating point value.
In addition to that, the parameter's name should be integer-like. (-1, 0, 1, 2) without pre/post prefix